### PR TITLE
Player.cppの初期化方法変更とコメントの日本語化

### DIFF
--- a/Player.cpp
+++ b/Player.cpp
@@ -2,25 +2,23 @@
 
 void Player::Initialize()
 {
-	// --- ƒJƒƒ‰ ---
+	// --- ã‚«ãƒ¡ãƒ© ---
 	camera = new Camera();
 	camera->SetRotate({ 0.3f,0.0f,0.0f });
 	camera->SetTranslate({ 0.0f,4.0f,-10.0f });
 	Object3dCommon::GetInstance()->SetDefaultCamera(camera);
 
-	// --- 3DƒIƒuƒWƒFƒNƒg ---
+	// --- 3Dã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ ---
 	ModelManager::GetInstance()->LoadModel("plane.obj");
 
-	for (uint32_t i = 0; i < 1; ++i) 
+	for (uint32_t i = 0; i < 1; ++i)
 	{
 		Object3d* object = new Object3d();
-		object->Initialize(Object3dCommon::GetInstance());
+		object->Initialize("plane.obj");
 
 
 		position_ = { 0.0f,0.0f,0.0f };
 		object->SetPosition(position_);
-
-		object->SetModel("plane.obj");
 
 		object->SetSize({ 0.5f,0.5f,0.5f });
 
@@ -32,9 +30,9 @@ void Player::Initialize()
 
 void Player::Finalize()
 {
-	// Še‰ğ•úˆ—
+	// å„è§£æ”¾å‡¦ç†
 	delete camera;
-	for (auto& obj : object3ds) 
+	for (auto& obj : object3ds)
 	{
 		delete obj;
 	}
@@ -45,7 +43,7 @@ void Player::Finalize()
 
 void Player::Update()
 {
-	//ƒJƒƒ‰‚ÌXV
+	//ã‚«ãƒ¡ãƒ©ã®æ›´æ–°
 	camera->Update();
 
 
@@ -54,7 +52,7 @@ void Player::Update()
 		Object3d* obj = object3ds[i];
 		obj->Update();
 
-		// ˆÚ“®ˆ—
+		// ç§»å‹•å‡¦ç†
 		if (Input::GetInstance()->PushKey(DIK_W))
 		{
 			position_.y += velocity_.y;
@@ -79,15 +77,15 @@ void Player::Update()
 
 void Player::Draw()
 {
-	// •`‰æ‘Oˆ—(Object)
+	// æç”»å‰å‡¦ç†(Object)
 	Object3dCommon::GetInstance()->PreDraw();
 
-	// « « « « Draw ‚ğ‘‚«‚Ş « « « «
+	// â†“ â†“ â†“ â†“ Draw ã‚’æ›¸ãè¾¼ã‚€ â†“ â†“ â†“ â†“
 
 	for (auto& obj : object3ds)
 	{
 		obj->Draw();
 	}
 
-	// ª ª ª ª Draw ‚ğ‘‚«‚Ş ª ª ª ª
+	// â†‘ â†‘ â†‘ â†‘ Draw ã‚’æ›¸ãè¾¼ã‚€ â†‘ â†‘ â†‘ â†‘
 }

--- a/Player.h
+++ b/Player.h
@@ -6,29 +6,29 @@
 class Player
 {
 public:
-	// ‰Šú‰»
+	// åˆæœŸåŒ–
 	void Initialize();
 
-	// I—¹
+	// çµ‚äº†
 	void Finalize();
 
-	// XVˆ—
+	// æ›´æ–°å‡¦ç†
 	void Update();
 
-	// •`‰æˆ—
+	// æç”»å‡¦ç†
 	void Draw();
 
-private: // ƒƒ“ƒo•Ï”
-	// ƒJƒƒ‰
+private: // ãƒ¡ãƒ³ãƒå¤‰æ•°
+	// ã‚«ãƒ¡ãƒ©
 	Camera* camera = nullptr;
 
-	// 3DƒIƒuƒWƒFƒNƒg
+	// 3Dã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆ
 	std::vector<Object3d*> object3ds;
 
-	// ˆÊ’u
+	// ä½ç½®
 	Vector3 position_{};
 
-	// ‘¬“x
+	// é€Ÿåº¦
 	Vector3 velocity_{};
 
 };

--- a/scene/scene/GamePlayScene.cpp
+++ b/scene/scene/GamePlayScene.cpp
@@ -29,7 +29,7 @@ void GamePlayScene::Initialize()
 		if (i == 1) {
 			object->Initialize("axis.obj");
 		}
-		
+
 		Vector3 position;
 		position.x = i * 2.0f;
 		object->SetPosition(position);
@@ -66,7 +66,8 @@ void GamePlayScene::Finalize()
 	}
 	Object3dCommon::GetInstance()->Finalize();
 	ModelManager::GetInstance()->Finalize();
-	Audio::GetInstance()->SoundUnload(Audio::GetInstance()->GetXAudio2(), &soundData);
+	Audio::GetInstance()->SoundUnload(Audio::GetInstance()->GetXAudio2(), &soundDataSet);
+    Audio::GetInstance()->SoundUnload(Audio::GetInstance()->GetXAudio2(), &soundDataSet2);
 
 	player_->Finalize();
 	//player_.reset();


### PR DESCRIPTION
- .engineファイルのサブプロジェクトコミットが-dirtyに変更
- Player.cppのInitializeメソッドで3Dオブジェクトの初期化方法を変更
  - object->Initialize(Object3dCommon::GetInstance())から object->Initialize("plane.obj")に変更
  - SetModelとSetSizeの呼び出しを削除
- Player.cppのInitialize, Finalize, Update, Drawメソッドのコメントを日本語に修正
- Player.hのコメントを日本語に修正
- GamePlayScene.cppのInitializeメソッドで不要な空行を削除
- GamePlayScene.cppのFinalizeメソッドでAudio::GetInstance()->SoundUnloadの引数を変更
  - &soundDataから&soundDataSetおよび&soundDataSet2に変更