### PR TITLE
AABBとOBBの衝突判定を追加

### DIFF
--- a/Collision/CollisionManager/CollisionManager.h
+++ b/Collision/CollisionManager/CollisionManager.h
@@ -81,9 +81,14 @@ private:
     void DebugWindow();
     void CheckCollisionPair(Collider* _colA, Collider* _colB);
     void ProjectShapeOnAxis(const std::vector<Vector3>* _v, const Vector3& _axis, float& _min, float& _max);
+
     bool IsCollision(const AABB* _aabb1, const AABB* _aabb2);
-    bool IsCollision(const OBB* _obb1, const OBB* _obb2);
+    bool IsCollision(const AABB& _aabb, const Sphere& _sphere);
+
     bool IsCollision(const Sphere* _sphere1, const Sphere* _sphere2);
+    bool IsCollision(const OBB* _obb1, const OBB* _obb2);
+
+    bool IsCollision(const OBB& _obb, const Sphere& _sphere);
 
     float ProjectOntoAxis(const OBB* _obb, const Vector3& axis);
     bool OverlapOnAxis(const OBB* _obb1, const OBB* _obb2, const Vector3& axis);

--- a/imgui.ini
+++ b/imgui.ini
@@ -4,22 +4,22 @@ Size=400,400
 Collapsed=0
 
 [Window][Easing Parameters]
-Pos=717,103
-Size=500,600
-Collapsed=0
+Pos=669,701
+Size=532,184
+Collapsed=1
 
 [Window][Objects]
-Pos=75,95
-Size=166,174
+Pos=12,55
+Size=133,271
 Collapsed=0
 
 [Window][デバッグ]
-Pos=93,528
+Pos=515,701
 Size=442,155
-Collapsed=0
+Collapsed=1
 
 [Window][CollisionManager]
-Pos=780,324
+Pos=848,65
 Size=381,237
 Collapsed=0
 


### PR DESCRIPTION
`CollisionManager.cpp` に `#include` を追加し、`AABB` と `Sphere`、`OBB` と `Sphere` の衝突判定関数を `CollisionManager::IsCollision` に追加しました。これに伴い、`CollisionManager.h` にも関数の宣言を追加および変更しました。また、`imgui.ini` でウィンドウの位置とサイズを変更しました。