### PR TITLE
TD2_02ブランチへの切り替えコマンドを追加

### DIFF
--- a/commands/Pull_Easing_Repository.bat
+++ b/commands/Pull_Easing_Repository.bat
@@ -3,5 +3,6 @@
 cd ..\.Externals\Easing
 git stash
 git pull origin main
+git checkout TD2_02
 
 exit


### PR DESCRIPTION
`git checkout TD2_02` コマンドが追加されました。これにより、`git pull origin main` コマンドの後に `TD2_02` ブランチに自動的に切り替わるようになります。