### PR TITLE
DebugManagerのバグ修正とBossの位置変更

### DIFF
--- a/Helper/ImGuiDebugManager/DebugManager.cpp
+++ b/Helper/ImGuiDebugManager/DebugManager.cpp
@@ -122,7 +122,7 @@ void DebugManager::Window_Log()
     {
         ImGui::BeginChild("LogChild", ImVec2(300, 0), ImGuiChildFlags_Border);
 
-        ImGui::InputTextMultiline("##Log", textLog_.data(), textLog_.size(), ImVec2(-1, -1), #ImGuiInputTextFlags_ReadOnly);
+        ImGui::InputTextMultiline("##Log", textLog_.data(), textLog_.size(), ImVec2(-1, -1), ImGuiInputTextFlags_ReadOnly);
 
         ImGui::EndChild();
     }

--- a/Resources/CSV/Boss.csv
+++ b/Resources/CSV/Boss.csv
@@ -1,3 +1,3 @@
-Position,7.71464,0,9.07346,
+Position,0,0,4.8989,
 Scale,0.5,0.5,0.5,
 Rotation,0,0,0,


### PR DESCRIPTION
DebugManager.cppのDebugManager::Window_Log()関数において、ImGui::InputTextMultilineの引数から誤って含まれていた#記号を削除しました。これにより、コードが正しくコンパイルされるようになりました。 Boss.csvファイルにおいて、Positionの値を7.71464,0,9.07346から0,0,4.8989に変更しました。